### PR TITLE
remove dead references

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,7 +41,7 @@
          <section>
             <p><span style="cursor:pointer;" title="Android" class="fa fa-android fa-3x" onclick="display_section('android')"></span>&nbsp;&nbsp;&nbsp;&nbsp;<span style="cursor:pointer;" title="iOS" class="fa fa-apple fa-3x" onclick="display_section('ios')"></span>&nbsp;&nbsp;&nbsp;&nbsp;<span style="cursor:pointer;" title="Windows App" class="fa fa-windows fa-3x" onclick="display_section('windows')"></span></p>
             <p>Please click on above icons to navigate between Wikis.</p>
-            <p>Please use left sidebar to navigate between sections.&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Last Updated on: <strong>12-8-2016</strong></p>
+            <p>Please use left sidebar to navigate between sections.&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Last Updated on: <strong>2017-07-18</strong></p>
             <a id="forensics-tools" class="anchor" href="#forensics-tools" aria-hidden="true" style="display:block"></a>
             <h2><i class="fa fa-folder"></i> Forensics Tools <a href="#forensics-tools"><span class="octicon octicon-link"></span></a></h2>
             <ul>

--- a/index.html
+++ b/index.html
@@ -336,7 +336,7 @@
                   <p><a href="https://dexter.dexlabs.org/" target="_blank">Dexter</a> - Dexter is an interactive Android software analysis environment with collaboration features.</p>
                </li>
                <li>
-                  <p><a href="http://www.mobiseclab.org/eacus.jsp" target="_blank">Eacus</a> - A lite Android app analysis framework</p>
+                  <p><del><a href="http://www.mobiseclab.org/eacus.jsp" target="_blank">Eacus</a> - A lite Android app analysis framework<del></p>
                </li>
                <li>
                   <p><a href="http://mobilesandbox.org/" target="_blank">Mobile Sandbox</a> - The Mobile-Sandbox provides static and dynamic malware analysis combined with machine learning techniques for Android applications. </p>

--- a/index.html
+++ b/index.html
@@ -312,7 +312,7 @@
             <h2><i class="fa fa-globe"></i> Online Analyzers <a href="#online-analyzers"><span class="octicon octicon-link"></span></a></h2>
             <ul>
                <li>
-                  <p><a href="https://androidobservatory.org/" target="_blank">Android Observatory</a> - The Android Observatory is a web interface to a large repository of Android applications. It allows users to search or browse through thousands of Android apps and retrieve metadata for those apps. </p>
+                  <p><del><a href="https://androidobservatory.org/" target="_blank">Android Observatory</a> - The Android Observatory is a web interface to a large repository of Android applications. It allows users to search or browse through thousands of Android apps and retrieve metadata for those apps.</del></p>
                </li>
                <li>
                   <p><a href="http://www.decompileandroid.com/" target="_blank">Android APK Decompiler</a> - Decompiling APK files made easy. Online decompiler.</p>

--- a/index.html
+++ b/index.html
@@ -249,7 +249,7 @@
                   <p><a href="https://www.pnfsoftware.com/index" target="_blank">JEB</a> - The Interactive Android Decompiler</p>
                </li>
                <li>
-                  <p><a href="https://github.com/LifeForm-Labs/lobotomy" target="_blank">Lobotomy</a> - Lobotomy is an Android security toolkit that will automate different Android assessments and reverse engineering tasks. The goal of the Lobotomy toolkit is to provide a console environment, which would allow a user to load their target Android APK once, then have all the necessary tools without needing to exit that environment. The 1.2 release will remain open source.</p>
+                  <p><a href="https://github.com/AndroidSecurityTools/lobotomy" target="_blank">Lobotomy</a> - Lobotomy is an Android security toolkit that will automate different Android assessments and reverse engineering tasks. The goal of the Lobotomy toolkit is to provide a console environment, which would allow a user to load their target Android APK once, then have all the necessary tools without needing to exit that environment. The 1.2 release will remain open source.</p>
                </li>
                <li>
                   <p><a href="https://code.google.com/p/smali/" target="_blank">smali</a> - An assembler/disassembler for Android's dex format</p>

--- a/index.html
+++ b/index.html
@@ -324,7 +324,7 @@
                   <p><del><a href="http://anubis.iseclab.org/" target="_blank">Anubis</a> - Malware Analysis for Unknown Binaries.</del></p>
                </li>
                <li>
-                  <p><a href="http://www.mobiseclab.org/akana/Intro.html" target="_blank">Akana</a> - Akana is an online Android app Interactive Analysis Enviroment (IAE), which is combined with some plugins for checking the malicious app.</p>
+                  <p><del><a href="http://www.mobiseclab.org/akana/Intro.html" target="_blank">Akana</a> - Akana is an online Android app Interactive Analysis Enviroment (IAE), which is combined with some plugins for checking the malicious app.</del></p>
                </li>
                <li>
                   <p><a href="http://www.app360scan.com/" target="_blank">App360Scan</a> - Tells about permissons used by an Application and what harm it can cause to users.</p>

--- a/index.html
+++ b/index.html
@@ -327,7 +327,7 @@
                   <p><del><a href="http://www.mobiseclab.org/akana/Intro.html" target="_blank">Akana</a> - Akana is an online Android app Interactive Analysis Enviroment (IAE), which is combined with some plugins for checking the malicious app.</del></p>
                </li>
                <li>
-                  <p><a href="http://www.app360scan.com/" target="_blank">App360Scan</a> - Tells about permissons used by an Application and what harm it can cause to users.</p>
+                  <p><del><a href="http://www.app360scan.com/" target="_blank">App360Scan</a> - Tells about permissons used by an Application and what harm it can cause to users.<del></p>
                </li>
                <li>
                   <p><a href="http://copperdroid.isg.rhul.ac.uk/copperdroid/" target="_blank">CopperDroid</a> - It automatically perform out-of-the-box dynamic behavioral analysis of Android malware.</p>

--- a/index.html
+++ b/index.html
@@ -321,7 +321,7 @@
                   <p><a href="http://andrototal.org/" target="_blank">AndroidTotal</a> - AndroTotal is a free service to scan suspicious APKs against multiple mobile antivirus apps.</p>
                </li>
                <li>
-                  <p><a href="http://anubis.iseclab.org/" target="_blank">Anubis</a> - Malware Analysis for Unknown Binaries.</p>
+                  <p><del><a href="http://anubis.iseclab.org/" target="_blank">Anubis</a> - Malware Analysis for Unknown Binaries.</del></p>
                </li>
                <li>
                   <p><a href="http://www.mobiseclab.org/akana/Intro.html" target="_blank">Akana</a> - Akana is an online Android app Interactive Analysis Enviroment (IAE), which is combined with some plugins for checking the malicious app.</p>

--- a/index.html
+++ b/index.html
@@ -198,7 +198,7 @@
                <li>
                   <p><a href="https://github.com/androguard/androguard" target="_blank">Androguard</a> - Reverse engineering, Malware and goodware analysis of Android applications ... and more (ninja !)</p>
                </li>
-			   <li>
+	       <li>
                   <p><a href="http://www.javadecompilers.com/apk" target="_blank">Android Apk decompiler</a> - Online decompile for Apk and Dex Android files</p>
                </li>
                <li>
@@ -216,8 +216,12 @@
                <li>
                   <p><a href="https://github.com/Konloch/bytecode-viewer" target="_blank">Bytecode-Viewer</a> - A Java 8 Jar &amp; Android APK Reverse Engineering Suite (Decompiler, Editor, Debugger &amp; More)</p>
                </li>
-               <li><p><a href="http://www.api-solutions.com/p/classyshark.html" target="_blank">ClassyShark</a> - Android executables browser for analyzing APKs.</p></li>
-			   <li><p><a href="http://sseblog.ec-spride.de/2014/12/codeinspect/" target="_blank">CodeInspect</a> - A Jimple-based Reverse-Engineering framework for Android and Java applications.</p></li>
+               <li>
+		  <p><a href="https://github.com/google/android-classyshark" target="_blank">ClassyShark</a> - Android executables browser for analyzing APKs.</p>
+	       </li>
+	       <li>
+		  <p><a href="http://sseblog.ec-spride.de/2014/12/codeinspect/" target="_blank">CodeInspect</a> - A Jimple-based Reverse-Engineering framework for Android and Java applications.</p>
+	       </li>
                <li>
                   <p><a href="https://github.com/mariokmk/dedex" target="_blank">dedex</a> - A command line tool for disassembling Android DEX files.</p>
                </li>
@@ -260,7 +264,7 @@
                <li>
                   <p><a href="https://github.com/cx9527/strongdb" target="_blank">Strongdb</a> - Strongdb is a gdb plugin that is written in Python, to help with debugging Android Native program.The main code uses gdb Python API.</p>
                </li>
-			   <li>
+	       <li>
                   <p><a href="https://github.com/ajinabraham/Xenotix-APK-Reverser" target="_blank">Xenotix APK Reverser</a> - An open source Android Application Package (APK) decompiler and disassembler powered by dex2jar, baksmali and jd-core</p>
                </li>
             </ul>


### PR DESCRIPTION
I found a number of online resources to be inaccessible. In most cases the websites are gone entirely. I loaded each URL in the "Online Analyzers" section to find the ones that didn't work. I then used the HTML5-compatible "\<del\>\</del\>" tags to strike through the ones that don't load.